### PR TITLE
Make VoteFactory choose a Keg in the Poll.

### DIFF
--- a/backend/tests/test_kegstarter/test_votingbooth/factories.py
+++ b/backend/tests/test_kegstarter/test_votingbooth/factories.py
@@ -13,6 +13,8 @@ class PollFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def kegs_available(self, create, extracted, **kwargs):
+        if create:
+            self.kegs_available.add(KegFactory())
         if extracted:
             self.kegs_available.add(*extracted)
 
@@ -30,6 +32,6 @@ class VoteFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'votingbooth.Vote'
 
-    keg = factory.SubFactory(KegFactory)
+    keg = factory.LazyAttribute(lambda o: o.poll.kegs_available.all()[0])
     poll = factory.SubFactory(PollFactory)
     user = factory.SubFactory(UserFactory)


### PR DESCRIPTION
Fixes #18.

There was a validation error if you tried to instantiate
a VoteFactory without arguments because it used a Keg
that wasn't in the Poll it created.

Some tests worked around this by creating their own factory
instances for vote fields. This commit refactors those out,
partly to clean up after an old bug and partly so future
changes are less likely to require combing through tests for
factory instantiations that override default behavior.